### PR TITLE
resolve certificate chain sequence bug

### DIFF
--- a/ACME-PS/internal/classes/crypto/Certificate.ps1
+++ b/ACME-PS/internal/classes/crypto/Certificate.ps1
@@ -30,7 +30,7 @@ class Certificate {
     }
 
     # note: this returns issuers before the certs they've issued.  This is the opposite order to what's desired; but is the order that produces the correct output when combined with the X509Certificate2Collection's Export command
-    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([Collections.ArrayList] $acmeCertificates) {
+    hidden static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([Collections.ArrayList] $acmeCertificates) {
         $result = [Security.Cryptography.X509Certificates.X509Certificate2Collection]::new();
         # process any quick wins (i.e. where it's clear there's no dependency
         $todoCount = $acmeCertificates.Count - 1;
@@ -59,7 +59,7 @@ class Certificate {
         return $result;
     }
 
-    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([byte[][]] $acmeCertificates, [Security.Cryptography.AsymmetricAlgorithm] $algorithm) {
+    hidden static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([byte[][]] $acmeCertificates, [Security.Cryptography.AsymmetricAlgorithm] $algorithm) {
         $certs = [Collections.ArrayList]::new();
         $certs.Add([Certificate]::CreateX509WithKey($acmeCertificates[0], $algorithm));
         for($i = 1; $i -lt $acmeCertificates.Length; $i++) {

--- a/dist/ACME-PS/ACME-PS.psm1
+++ b/dist/ACME-PS/ACME-PS.psm1
@@ -268,25 +268,26 @@ class Certificate {
         }
     }
 
-    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]] $acmeCertificates) {
+    # note: this returns issuers before the certs they've issued.  This is the opposite order to what's desired; but is the order that produces the correct output when combined with the X509Certificate2Collection's Export command
+    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([Collections.ArrayList] $acmeCertificates) {
         $result = [Security.Cryptography.X509Certificates.X509Certificate2Collection]::new();
-        $todo = [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]::new();
         # process any quick wins (i.e. where it's clear there's no dependency
-        foreach ($cert in $acmeCertificates) {
-            if ([string]::IsNullOrWhitespace($cert.Issuer) -or ($cert.Subject -eq $cert.Issuer)) {
-                $result.Add($cert); #| out-null
-            } else {
-                $todo.Add($cert);
+        $todoCount = $acmeCertificates.Count - 1;
+        for ($i = $todoCount; $i -ge 0; $i--) {
+            if ([string]::IsNullOrWhitespace($acmeCertificates[$i].Issuer) -or ($acmeCertificates[$i].Subject -eq $acmeCertificates[$i].Issuer)) {
+                $result.Add($acmeCertificates[$i]); #| out-null
+                $acmeCertificates.RemoveAt($i);
             }
         }
-        # then work through the chains
-        while ($todoCount = $todo.Count) {
+        # then work through the chains, returning all certificates whose issuers aren't in the unprocessed collection
+        $todoSubjects = [Collections.ArrayList]::new( ($acmeCertificates | Select-Object -ExpandProperty 'Subject') );
+        while ($todoCount = $acmeCertificates.Count) {
             $circularLoop = $true;
-            $todoSubjects = $todo | Select-Object -ExpandProperty 'Subject';
             for ($i = ($todoCount - 1); $i -ge 0; $i--) {
-                if ($todo[$i].Issuer -notin $todoSubjects) {
-                    $result.Add($todo[$i]); #| out-null
-                    $todo.RemoveAt($i);
+                if (!$todoSubjects.Contains($acmeCertificates[$i].Issuer)) {
+                    $result.Add($acmeCertificates[$i]); #| out-null
+                    $todoSubjects.Remove($acmeCertificates[$i].Subject);
+                    $acmeCertificates.RemoveAt($i);
                     $circularLoop = $false;
                 }
             }
@@ -298,7 +299,7 @@ class Certificate {
     }
 
     static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([byte[][]] $acmeCertificates, [Security.Cryptography.AsymmetricAlgorithm] $algorithm) {
-        [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]$certs = [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]::new();
+        $certs = [Collections.ArrayList]::new();
         $certs.Add([Certificate]::CreateX509WithKey($acmeCertificates[0], $algorithm));
         for($i = 1; $i -lt $acmeCertificates.Length; $i++) {
             $certs.Add([Security.Cryptography.X509Certificates.X509Certificate2]::new($acmeCertificates[$i]));

--- a/dist/ACME-PS/ACME-PS.psm1
+++ b/dist/ACME-PS/ACME-PS.psm1
@@ -268,18 +268,51 @@ class Certificate {
         }
     }
 
+    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]] $acmeCertificates) {
+        $result = [Security.Cryptography.X509Certificates.X509Certificate2Collection]::new();
+        $todo = [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]::new();
+        # process any quick wins (i.e. where it's clear there's no dependency
+        foreach ($cert in $acmeCertificates) {
+            if ([string]::IsNullOrWhitespace($cert.Issuer) -or ($cert.Subject -eq $cert.Issuer)) {
+                $result.Add($cert); #| out-null
+            } else {
+                $todo.Add($cert);
+            }
+        }
+        # then work through the chains
+        while ($todoCount = $todo.Count) {
+            $circularLoop = $true;
+            $todoSubjects = $todo | Select-Object -ExpandProperty 'Subject';
+            for ($i = ($todoCount - 1); $i -ge 0; $i--) {
+                if ($todo[$i].Issuer -notin $todoSubjects) {
+                    $result.Add($todo[$i]); #| out-null
+                    $todo.RemoveAt($i);
+                    $circularLoop = $false;
+                }
+            }
+            if ($circularLoop) {
+                throw [System.ArgumentException]::new("There appears to be a circular loop in the given certificate's dependency chain"); # I don't think this would ever occur; but maybe it's a risk for some self signed cert scenarios?
+            }
+        }
+        return $result;
+    }
+
+    static [Security.Cryptography.X509Certificates.X509Certificate2Collection] ConvertToCertificateCollection([byte[][]] $acmeCertificates, [Security.Cryptography.AsymmetricAlgorithm] $algorithm) {
+        [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]$certs = [System.Collections.Generic.List[Security.Cryptography.X509Certificates.X509Certificate2]]::new();
+        $certs.Add([Certificate]::CreateX509WithKey($acmeCertificates[0], $algorithm));
+        for($i = 1; $i -lt $acmeCertificates.Length; $i++) {
+            $certs.Add([Security.Cryptography.X509Certificates.X509Certificate2]::new($acmeCertificates[$i]));
+        }
+        return [Certificate]::ConvertToCertificateCollection($certs);
+    }
+
     static [byte[]] ExportPfxCertificateChain([byte[][]] $acmeCertificates, [AcmePSKey] $key, [SecureString] $password) {
         return [Certificate]::ExportPfxCertificateChain($acmeCertificates, $key.GetAlgorithm(), $password);
     }
 
     static [byte[]] ExportPfxCertificateChain([byte[][]] $acmeCertificates, [Security.Cryptography.AsymmetricAlgorithm] $algorithm, [securestring] $password) {
-        $leafCertificate = [Certificate]::CreateX509WithKey($acmeCertificates[0], $algorithm);
-        $certificateCollection = [Security.Cryptography.X509Certificates.X509Certificate2Collection]::new($leafCertificate);
 
-        for($i = 1; $i -lt $acmeCertificates.Length; $i++) {
-            $chainCert = [Security.Cryptography.X509Certificates.X509Certificate2]::new($acmeCertificates[$i]);
-            $certificateCollection.Add($chainCert);
-        }
+        $certificateCollection = [Certificate]::ConvertToCertificateCollection($acmeCertificates, $algorithm);
 
         if($password) {
             $unprotectedPassword = [PSCredential]::new("ACME-PS", $password).GetNetworkCredential().Password;


### PR DESCRIPTION
Similar to the report in #120, it seems that sometimes the full chain in a PFX is created in the wrong order.
In most scenarios this doesn't have any impact, as most devices resolve any missing or out of order certificates for themselves; however in some scenarios (e.g. older Android devices / Java clients) there can be issues.  [SSL Labs](https://www.ssllabs.com/ssltest/analyze.html?d=example.com ) shows a warning "Chain issues: Incorrect Order" in such cases.

This fix ensures that the PFX generated for a certificate chain has all certs in the correct order; i.e. client, intermediate(s), root.
