### PR TITLE
Add missing export keys

### DIFF
--- a/ACME-PS/ACME-PS.psd1
+++ b/ACME-PS/ACME-PS.psd1
@@ -64,6 +64,10 @@
 
 		"Invoke-SignedWebRequest"
 	)
+	CmdletsToExport = @()
+	VariablesToExport = @()
+	AliasesToExport = @()
+	DscResourcesToExport = @()
 
 	# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 	PrivateData = @{


### PR DESCRIPTION
Adds the missing export keys as described here: https://github.com/PKISharp/ACME-PS/issues/135
This will enable PowerShell to do the command discovery for this module quicker.

Note that I'm assuming this module isn't exporting any cmdlets, variables, aliases or DSC resources. If it is, then the exports needs to be updated to list those.